### PR TITLE
Zips: encode files as unicode

### DIFF
--- a/lib/perl/Backend/FS/Driver.pm
+++ b/lib/perl/Backend/FS/Driver.pm
@@ -323,6 +323,7 @@ sub uncompress_archive {
     my ( $self, $zipfile, $destination ) = @_;
     my $ret = 1;
     require Archive::Zip;
+    local $Archive::Zip::UNICODE = 1;
     my $zip    = Archive::Zip->new();
     my $status = $zip->read( $self->resolveVirt($zipfile) );
     if ( $ret = $status eq $zip->AZ_OK ) {
@@ -336,6 +337,7 @@ sub compress_files {
 
     require Archive::Zip;
     my $zip = Archive::Zip->new();
+    local $Archive::Zip::UNICODE = 1;
     foreach my $file (@files) {
         if ( $self->isDir( $basepath . $file ) ) {
             $zip->addTree( $self->resolveVirt( $basepath . $file ), $file );

--- a/lib/perl/Backend/GIT/Driver.pm
+++ b/lib/perl/Backend/GIT/Driver.pm
@@ -134,6 +134,7 @@ sub compress_files {
     my ( $self, $desthandle, $basepath, @files ) = @_;
 
     require Archive::Zip;
+    local $Archive::Zip::UNICODE = 1;
     my $zip       = Archive::Zip->new();
     my $gitfilter = sub {
         return !$self->gitFilter( $self->dirname($_), $self->basename($_) );
@@ -159,6 +160,7 @@ sub uncompress_archive {
     my ( $self, $zipfile, $destination ) = @_;
     my $ret = 1;
     require Archive::Zip;
+    local $Archive::Zip::UNICODE = 1;
     my $zip    = Archive::Zip->new();
     my $status = $zip->read( $self->resolveVirt($zipfile) );
     $ret = $status eq $zip->AZ_OK;

--- a/lib/perl/Backend/Helper.pm
+++ b/lib/perl/Backend/Helper.pm
@@ -60,6 +60,7 @@ sub compress_files {
     my $tempdir =
       tempdir( '/tmp/webdavcgi-compress-files-XXXXX', CLEANUP => 1 );
     require Archive::Zip;
+    local $Archive::Zip::UNICODE = 1;
     my $zip = Archive::Zip->new();
     foreach my $file (@files) {
         $self->_copytolocal( "$tempdir/", "$basepath$file" );

--- a/lib/perl/WebInterface/Extension/Localizer.pm
+++ b/lib/perl/WebInterface/Extension/Localizer.pm
@@ -203,6 +203,7 @@ sub _handle_download_all_locales {
                 ;
 
     require Archive::Zip;
+    local $Archive::Zip::UNICODE = 1;
     my $zip = Archive::Zip->new();
     foreach my $fn ( glob $glob ) {
         $zip->addFile( $fn, $fn=~/^${INSTALL_BASE}(.*)$/xms ? $1 : $fn);
@@ -221,6 +222,7 @@ sub _handle_download_all_locales {
 sub _handle_zipped_text_download {
     my ($self, $content, $zipfilename ) = @_;
     require Archive::Zip;
+    local $Archive::Zip::UNICODE = 1;
     my $zip = Archive::Zip->new();
     foreach my $filename (sort keys %{$content}) {
         my $textref = $content->{$filename};


### PR DESCRIPTION
On modern versions of Windows, the filenames encoded with the
default encoding do not correctly extract files with special
characters e.g. french accents. Specify that filenames are to
be Unicode (UTF-8) encoded to try to avoid this. Unfortunately,
Windows zip read/write is flaky so this probably won't handle
every use case, but this should handle more cases than before.