### PR TITLE
Fix Backend SMB Driver error

### DIFF
--- a/lib/perl/Backend/SMB/Driver.pm
+++ b/lib/perl/Backend/SMB/Driver.pm
@@ -144,7 +144,7 @@ sub _read_dir_root {
                     "$DOCUMENT_ROOT$fserver$_SHARESEP$$f[1]",
                     { type => $f->[0], comment => $f->[2] }
                 );
-                if ( $f->[0] == $self->smbclient->SMBC_FILE_SHARE
+                if ( $f->[0] == $smbclient->SMBC_FILE_SHARE
                     && ( !defined $sfilter || $f->[1] !~ /$sfilter/xms ) )
                 {
                     push @files, "$fserver$_SHARESEP$$f[1]";


### PR DESCRIPTION
@DanRohde - We did try the RC and we did get it work after some tweaking however, the issue I had before still remains. I am not a perl dev, however this PR shows you what I did to get it to work. Maybe it will shine some light on what the real issue is?

With this tweak I do not get the below errors any more. 

Error with out any tweaks to file:
```
Can't locate object method "smbclient" via package "Backend::SMB::Driver" at /var/www/webdavcgi/lib/perl/Backend/SMB/Driver.pm line 147.
```

Once I got the page loading, I saw where it looks like translation issues?  See screen shot below. 

<img width="1432" alt="screen shot 2017-06-05 at 9 22 20 pm" src="https://cloud.githubusercontent.com/assets/9731860/26810976/e3dd3c06-4a3c-11e7-85d1-78f764ba165a.png">

Not sure if this is a bug or not. IF there is a bug tracker somewhere I would be glad to fill one out. Just point me in the right direction.

